### PR TITLE
Fix handling of codepoints >= 0xe000

### DIFF
--- a/cbor.js
+++ b/cbor.js
@@ -129,7 +129,7 @@ function encode(value) {
           } else if (charCode < 0x800) {
             utf8data.push(0xc0 | charCode >> 6);
             utf8data.push(0x80 | charCode & 0x3f);
-          } else if (charCode < 0xd800) {
+          } else if (charCode < 0xd800 || charCode >= 0xe000) {
             utf8data.push(0xe0 | charCode >> 12);
             utf8data.push(0x80 | (charCode >> 6)  & 0x3f);
             utf8data.push(0x80 | charCode & 0x3f);


### PR DESCRIPTION
Codepoints in [U+E000,U+FFFF] were handled by the surrogate pair
code path.